### PR TITLE
(chore) Refactor ngOnInit logic cater for existing login

### DIFF
--- a/src/app/links/links.component.html
+++ b/src/app/links/links.component.html
@@ -10,3 +10,5 @@
     </md-card>
   </md-grid-tile>
 </md-grid-list>
+
+<md-card *ngIf="error">Error: {{error}}</md-card>

--- a/src/app/links/links.component.ts
+++ b/src/app/links/links.component.ts
@@ -13,6 +13,9 @@ import { Link } from './link';
 export class LinksComponent implements OnInit {
   requestObject: any;
   links: any;
+  teamId: string;
+  authObject: any;
+  error: any;
 
   constructor(
     private route: ActivatedRoute,
@@ -20,27 +23,53 @@ export class LinksComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.route.queryParams.subscribe(val => {
-      this.requestObject = {
-        client_id: '126735187141.129500575763',
-        client_secret: '4c0774074e25b401c9cfa98faa735b84',
-        code: val['code'],
-      };
-    });
-
-    this.linksService.getAccessToken(this.requestObject).subscribe(
-      token => {
-        localStorage.setItem('rinku', JSON.stringify(token));
-
-        this.linksService.getLinks(token.team.id).subscribe(
-          links => {
-            this.links = links;
-          },
-          error => console.log(error)
-        )
-      },
+    this.authObject = JSON.parse(localStorage.getItem('rinku'));
+    this.route.queryParams.subscribe(
+      val => {
+        this.requestObject = {
+          client_id: '126735187141.129500575763',
+          client_secret: '4c0774074e25b401c9cfa98faa735b84',
+          code: val['code'],
+        };
+      }, 
       error => console.log(error)
     );
-  }
 
+    if (this.requestObject.code) {
+      this.linksService.getAccessToken(this.requestObject).subscribe(
+        token => {
+          localStorage.setItem('rinku', JSON.stringify(token));
+
+          if (JSON.parse(localStorage.getItem('rinku')).ok) {
+            this.linksService.getLinks(token.team.id).subscribe(
+              links => {
+                this.links = links;
+              },
+              error => console.log(error)
+            )  
+          } else {
+            this.error = JSON.parse(localStorage.getItem('rinku')).error;
+          }
+        },
+        error => console.log(error)
+      );
+    } else {
+      if (this.authObject) {    
+        if(this.authObject.ok) {
+          this.teamId = JSON.parse(localStorage.getItem('rinku')).team.id;
+
+          this.linksService.getLinks(this.teamId).subscribe(
+            links => {
+              this.links = links;
+            },
+            error => console.log(error)
+          )
+        } else {
+          this.error = this.authObject.error;
+        }
+      } else {
+        this.error = 'You need to sign in to see anything on this page';
+      }
+    }
+  }
 }


### PR DESCRIPTION
#### What does this PR do?
This PR refactors login logic to ensure that if a user is already logged in, a request is not sent to attempt to log them in again.

This is the auth flow:
1. When the page `/links` is accessed, the component checks if the `rinku` `authObject` already exists in localStorage and also gets any route params and puts them in a `requestObject` variable.

2. For all cases where `requestObject.code` **is defined**, i.e a code exists in the query parameters when `/links` was accessed, a request is sent for a new `authObject` and if that is successful, links are fetched. The reason requests are sent in all cases where a code exists (even though there could be a valid `authObject` already) is that when there is an invalid `authObject`, the user will see an error instead of having his auth code used to refresh his login.

3. If `requestObject.code` **is undefined** i.e `/links` was accessed with no query params, the component will check if an `authObject` already exists in localStorage. If it does and its `ok` key has the value `true`, links will be fetched. If the value of `ok` is `false`, `error` will be set to `authObject.error` and displayed by the component. If the `authObject` does not exist at all, `error` will be set to a message informing the user to log in.