### PR TITLE
Fix link fetching

### DIFF
--- a/src/app/links/links.component.html
+++ b/src/app/links/links.component.html
@@ -10,3 +10,5 @@
     </md-card>
   </md-grid-tile>
 </md-grid-list>
+
+<md-card *ngIf="error">Error: {{error}}</md-card>

--- a/src/app/links/links.component.ts
+++ b/src/app/links/links.component.ts
@@ -13,6 +13,9 @@ import { Link } from './link';
 export class LinksComponent implements OnInit {
   requestObject: any;
   links: any;
+  teamId: string;
+  authObject: any;
+  error: any;
 
   constructor(
     private route: ActivatedRoute,
@@ -20,27 +23,53 @@ export class LinksComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.route.queryParams.subscribe(val => {
-      this.requestObject = {
-        client_id: '126735187141.129500575763',
-        client_secret: '4c0774074e25b401c9cfa98faa735b84',
-        code: val['code'],
-      };
-    });
-
-    this.linksService.getAccessToken(this.requestObject).subscribe(
-      token => {
-        localStorage.setItem('rinku', JSON.stringify(token));
-
-        this.linksService.getLinks(token.team.id).subscribe(
-          links => {
-            this.links = links;
-          },
-          error => console.log(error)
-        )
-      },
+    this.authObject = JSON.parse(localStorage.getItem('rinku'));
+    this.route.queryParams.subscribe(
+      val => {
+        this.requestObject = {
+          client_id: '126735187141.129500575763',
+          client_secret: '4c0774074e25b401c9cfa98faa735b84',
+          code: val['code'],
+        };
+      }, 
       error => console.log(error)
     );
-  }
 
+    if (this.requestObject.code) {
+      this.linksService.getAccessToken(this.requestObject).subscribe(
+        token => {
+          localStorage.setItem('rinku', JSON.stringify(token));
+
+          if (JSON.parse(localStorage.getItem('rinku')).ok) {
+            this.linksService.getLinks(token.team.id).subscribe(
+              links => {
+                this.links = links;
+              },
+              error => console.log(error)
+            )  
+          } else {
+            this.error = JSON.parse(localStorage.getItem('rinku')).error;
+          }
+        },
+        error => console.log(error)
+      );
+    } else {
+      if (this.authObject) {    
+        if(this.authObject.ok) {
+          this.teamId = JSON.parse(localStorage.getItem('rinku')).team.id;
+
+          this.linksService.getLinks(this.teamId).subscribe(
+            links => {
+              this.links = links;
+            },
+            error => console.log(error)
+          )
+        } else {
+          this.error = this.authObject.error;
+        }
+      } else {
+        this.error = 'You need to sign in to see anything on this page';
+      }
+    }
+  }
 }

--- a/src/app/links/links.component.ts
+++ b/src/app/links/links.component.ts
@@ -23,6 +23,8 @@ export class LinksComponent implements OnInit {
   ) { }
 
   ngOnInit() {
+    let self = this;
+    
     this.authObject = JSON.parse(localStorage.getItem('rinku'));
     this.route.queryParams.subscribe(
       val => {
@@ -35,38 +37,62 @@ export class LinksComponent implements OnInit {
       error => console.log(error)
     );
 
-    if (this.requestObject.code) {
-      this.linksService.getAccessToken(this.requestObject).subscribe(
-        token => {
-          localStorage.setItem('rinku', JSON.stringify(token));
+    function getAccessToken(requestObject) {
 
-          if (JSON.parse(localStorage.getItem('rinku')).ok) {
-            this.linksService.getLinks(token.team.id).subscribe(
-              links => {
-                this.links = links;
-              },
-              error => console.log(error)
-            )  
-          } else {
-            this.error = JSON.parse(localStorage.getItem('rinku')).error;
-          }
-        },
-        error => console.log(error)
-      );
-    } else {
-      if (this.authObject) {    
-        if(this.authObject.ok) {
-          this.teamId = JSON.parse(localStorage.getItem('rinku')).team.id;
+    }
 
-          this.linksService.getLinks(this.teamId).subscribe(
-            links => {
-              this.links = links;
+    if (this.authObject) {    
+      if(this.authObject.ok) {
+        this.teamId = JSON.parse(localStorage.getItem('rinku')).team.id;
+
+        this.linksService.getLinks(this.teamId).subscribe(
+          links => {
+            this.links = links;
+          },
+          error => console.log(error)
+        )
+      } else {
+        if (this.requestObject.code) {
+          this.linksService.getAccessToken(this.requestObject).subscribe(
+            token => {
+              localStorage.setItem('rinku', JSON.stringify(token));
+
+              if (JSON.parse(localStorage.getItem('rinku')).ok) {
+                this.linksService.getLinks(token.team.id).subscribe(
+                  links => {
+                    this.links = links;
+                  },
+                  error => console.log(error)
+                )  
+              } else {
+                this.error = JSON.parse(localStorage.getItem('rinku')).error;
+              }
             },
             error => console.log(error)
-          )
+          );
         } else {
           this.error = this.authObject.error;
         }
+      }
+    } else {
+       if (this.requestObject.code) {
+        this.linksService.getAccessToken(this.requestObject).subscribe(
+          token => {
+            localStorage.setItem('rinku', JSON.stringify(token));
+
+            if (JSON.parse(localStorage.getItem('rinku')).ok) {
+              this.linksService.getLinks(token.team.id).subscribe(
+                links => {
+                  this.links = links;
+                },
+                error => console.log(error)
+              )  
+            } else {
+              this.error = JSON.parse(localStorage.getItem('rinku')).error;
+            }
+          },
+          error => console.log(error)
+        );
       } else {
         this.error = 'You need to sign in to see anything on this page';
       }

--- a/src/app/links/token.ts
+++ b/src/app/links/token.ts
@@ -1,8 +1,10 @@
 export class Token {
   constructor(
+    public ok: any,
     public access_token: String,
     public scope: any,
     public user: any,
     public team: any,
+    public error: any,
   ) { }
 }


### PR DESCRIPTION
#### What does this PR do?
This PR refactors login logic to ensure that if a user is already logged in, a request is not sent to attempt to log them in again.

This is the auth flow:
1. When the page `/links` is accessed, the component checks if the `rinku` `authObject` already exists in localStorage and also gets any route params and puts them in a `requestObject` variable.

2. If `authObject` exists and it has a key `ok` with the value `true`, links are fetched.

3. If `authObject` has key `ok` with value `false`, 2 things can happen:
- If there is a code in the `requestObject`, then a new `authObject` is requested from slack and links are then fetched.
- If there is no code in `requestObject`, the component is rendered with `error` set to the existing `authObject.error`

4. If `authObject` does not exist but a code exists in `requestObject`, an `authObject` is requested from slack and links are fetched. If there is no `authObject` and no code in `requestObject`, the component is rendered with `error = 'You need to sign in to see anything on this page'`

NB: The error messages can be changed later to be more meaningful based on how we will implement the UI.
