### PR TITLE
Check for existing session when landing on home page

### DIFF
--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { LocalStorageService } from 'ng2-webstorage';
 
 @Component({
   selector: 'app-home',
@@ -7,9 +9,18 @@ import { Component, OnInit } from '@angular/core';
 })
 export class HomeComponent implements OnInit {
 
-  constructor() { }
+  constructor(
+    private router: Router,
+    private storage: LocalStorageService
+  ) { 
+    const authDetails = this.storage.retrieve('rinku');
 
-  ngOnInit() {
+    if(authDetails) {
+      if(authDetails.ok) {
+        this.router.navigateByUrl('/links');
+      }
+    }
   }
 
+  ngOnInit() {}
 }


### PR DESCRIPTION
#### What does this PR do?
This PR modifies the Home component so that on initialization, it checks if a valid authentication object exists in the user's browser local storage. If it does, it redirects the user to the links dashboard. 

If none exists, the home component is rendered.

This addresses #13 

#### How should this be manually tested?
1. Log in and confirm that you can see links on the dashboard.
2. Without logging out, close the links dashboard tab and try accessing the home page on a fresh tab on the same browser. You should be redirected automatically to the links dashboard page.

#### Additional Information
@JackMwangi For whatever reason running the system still does not render links when I do fresh logins. I have to do a page refresh every time I log in for the links to be fetched. Please test this out on your machine using this branch.